### PR TITLE
update: SWEA_1767 - 프로세서 연결하기

### DIFF
--- a/java_practice/SWEA/Solution_1767.java
+++ b/java_practice/SWEA/Solution_1767.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.StringTokenizer;
 
 public class Solution_1767 {
+
     /**
      * SWEA 1767 : 프로세서 연결하기
      * 이미 설치된 각 프로세서 코어와 멕시노스 외부를 잇는 전선을 직선으로 설치. 단, 이미 가장자리에 있는 코어는 연결된 것으로 간주.


### PR DESCRIPTION
[solve/SWEA_1767] - hmSON-7
 --- 
 ## 📝 문제 정보
문제 번호: <!-- SWEA_1767 -->
문제 이름: <!-- 프로세서 연결하기 -->

---

✨ 풀이 요약
<!-- 어떤 접근 방식으로 풀었는지, 어떤 알고리즘/자료구조를 사용했는지 서술 -->
- 코어를 기준으로 4방향 탐색을 진행하는 완전 탐색
- 전선 설치에 따른 상황 변화를 실시간으로 적용하고, 사용된 전선을 회수하는 방안으로 재귀를 활용한 DFS 탐색 선택
- 원하는 조건에 맞는 순서대로 코어를 다루기 위해 리스트에 코어의 좌표 정보를 담은 뒤 정렬

---

⌛ 시간복잡도 분석
<!-- 시간복잡도 추정 -->
시간복잡도: O(N)
구체적으로는 코어 개수 C와 각 코어마다 나올 수 있는 가지
공간복잡도: O(N^2)

---

🔍 키워드 & 힌트
<!-- 문제를 보고 어떤 키워드가 눈에 띄었는지 작성 -->
"전선은 절대로 교차해서는 안된다" -> 백트래킹 또는 DFS로 경우의 수에 따른 상황 판단 요구
"멕시노스의 가장자리에 위치한 Core는 이미 전원이 연결된 것으로 간주" -> 리스트 자료구조로 특정 코어만 관리해야 함

---

📎 관련 문서 / 참고 링크 (선택)
- 

---

✅ 체크리스트
[x] 문제 조건을 정확히 이해했나요?
[x] 주석 또는 설명을 충분히 달았나요?
[x] 테스트 케이스는 충분히 확인했나요?